### PR TITLE
#7 Differentiate between Microsoft Office 2016 and 2019 with VSTO 

### DIFF
--- a/DiscordForOffice.sln
+++ b/DiscordForOffice.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiscordForPowerPoint", "DiscordForPowerPoint\DiscordForPowerPoint.csproj", "{8F6EAF0E-C731-4D94-85A2-DF6BD6F671F4}"
 EndProject
@@ -20,6 +20,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiscordForOutlook", "Discor
 		{3FFB6368-18CB-45ED-A36D-2CD8593382CB} = {3FFB6368-18CB-45ED-A36D-2CD8593382CB}
 		{819D20D6-8D88-45C1-A4D2-AA21F10ABD19} = {819D20D6-8D88-45C1-A4D2-AA21F10ABD19}
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{DD6D5F59-3B56-401F-8732-7F11ADDFCC75}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared.Tests", "Tests\Shared.Tests\Shared.Tests.csproj", "{6F113391-600C-41B9-9D56-D1FE92700C33}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -160,9 +164,30 @@ Global
 		{02B86A9E-53DA-428D-89FA-014BCD1CC26E}.Release|x64.Build.0 = Release|Any CPU
 		{02B86A9E-53DA-428D-89FA-014BCD1CC26E}.Release|x86.ActiveCfg = Release|Any CPU
 		{02B86A9E-53DA-428D-89FA-014BCD1CC26E}.Release|x86.Build.0 = Release|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug Unity|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug Unity|Any CPU.Build.0 = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug Unity|x64.ActiveCfg = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug Unity|x64.Build.0 = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug Unity|x86.ActiveCfg = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug Unity|x86.Build.0 = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Release|x64.Build.0 = Release|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F113391-600C-41B9-9D56-D1FE92700C33}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6F113391-600C-41B9-9D56-D1FE92700C33} = {DD6D5F59-3B56-401F-8732-7F11ADDFCC75}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8AC204BF-3DB2-4730-B963-F46747F6C755}

--- a/Shared/Shared.cs
+++ b/Shared/Shared.cs
@@ -53,7 +53,6 @@ namespace Shared
             {
                 // Ugly temporary work-around due to Microsoft assigning version 16 to both Office 2016 and 2019 
                 var fileName = Process.GetCurrentProcess().MainModule.FileVersionInfo.FileName;
-                var processes = Process.GetProcesses(); ;
 
                 if (fileName.Contains("2016"))
                 {

--- a/Shared/Shared.cs
+++ b/Shared/Shared.cs
@@ -20,7 +20,9 @@ namespace Shared
             {12, "2007" },
             {14, "2010" },
             {15, "2013" },
-            {16, "2016 or 2019" }
+            {16, "2016" },
+            {17, "2017" },
+            {18, "2019" }
         };
 
         private static IDictionary<string, string> Strings = new Dictionary<string, string>()
@@ -41,10 +43,32 @@ namespace Shared
             {"unknown_key", "[Unknown]" }
         };
 
-        public static String getVersion()
+        public static String GetVersion()
         {
             int version = Process.GetCurrentProcess().MainModule.FileVersionInfo.ProductMajorPart;
+
             Debug.WriteLine(ObjectDumper.Dump(Process.GetCurrentProcess().MainModule.FileVersionInfo));
+
+            if (version == 16)
+            {
+                // Ugly temporary work-around due to Microsoft assigning version 16 to both Office 2016 and 2019 
+                var fileName = Process.GetCurrentProcess().MainModule.FileVersionInfo.FileName;
+                var processes = Process.GetProcesses(); ;
+
+                if (fileName.Contains("2016"))
+                {
+                    return OfficeVersions[16];
+                }
+                else if (fileName.Contains("2017"))
+                {
+                    return OfficeVersions[17];
+                }
+                else if (fileName.Contains("2019"))
+                {
+                    return OfficeVersions[18];
+                }
+            }
+
             if (OfficeVersions.ContainsKey(version))
             {
                 return OfficeVersions[version];
@@ -74,7 +98,7 @@ namespace Shared
                 Assets = new Assets()
                 {
                     LargeImageKey = type + "_welcome",
-                    LargeImageText = getString(type) + " " + getVersion(),
+                    LargeImageText = getString(type) + " " + GetVersion(),
                     SmallImageKey = type
                 }
             };

--- a/Tests/Shared.Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Shared.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Shared.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Shared.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("6f113391-600c-41b9-9d56-d1fe92700c33")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Shared.Tests/Shared.Tests.csproj
+++ b/Tests/Shared.Tests/Shared.Tests.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6F113391-600C-41B9-9D56-D1FE92700C33}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Shared.Tests</RootNamespace>
+    <AssemblyName>Shared.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SharedTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Shared.csproj">
+      <Project>{3ffb6368-18cb-45ed-a36d-2cd8593382cb}</Project>
+      <Name>Shared</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/Tests/Shared.Tests/SharedTests.cs
+++ b/Tests/Shared.Tests/SharedTests.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Shared.Tests
+{
+    [TestClass]
+    public class SharedTests
+    {
+        [TestMethod]
+        public void GetVersion_WhenRunningProcessIsNotInOfficeVersionDictionary_ReturnsExpectedResult()
+        {
+            var result = Shared.GetVersion();
+        }
+    }
+}

--- a/Tests/Shared.Tests/packages.config
+++ b/Tests/Shared.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net48" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
This commit is an idea for a temporary workaround the weird path location from Office apps.

Since I do not have any actual Office exe's installed, I can't really test this stuff out. I've added a new unit test project so this repo can have some unit tests. This makes it a lot easier to debug and exercise the `Shared` class.

A couple of other thoughts:

1. Typically, C# uses `PascalCasing` instead of `camelCasing`. I renamed one method to follow the standard convention.
2. I would suggest instead encapsulating the knowledge of retrieving the version number of the running app to inside each library as opposed to this shared logic. `GetVersion()` is currently pretty much impossible to test because it reaches out to grab dependencies on the `Process` object. You might want to consider having this knowledge encapsulated to each class lib, then refactor `GetVersion` to take in this lib specific knowledge as a parameter and then it could figure things out. But having the Process.GetCurrentProcess() inside of this method makes it very hard to test. For example, when I debugged it, it gave me the version of Visual Studio running 💯 
3. My branching logic is just to give an example of some type of hack that might work for now, if you are able to provide me with some paths for the actual EXEs I would update them accordingly.
4. The Major version is 16, but it doesn't seem like the minor version was considered. I would dump/debug this value for each of the class libraries to see if you could pinpoint them that way
5. There might be some GUIDs associated with each product which might be better to use instead of the product major version:

https://docs.microsoft.com/en-us/office/troubleshoot/office-developer/find-office-installation-path

https://docs.microsoft.com/en-us/office/troubleshoot/reference/numbering-scheme-for-product-guid
